### PR TITLE
Don't convert boolean values to string

### DIFF
--- a/www/js/homematic-manager.js
+++ b/www/js/homematic-manager.js
@@ -253,7 +253,8 @@ $(document).ready(function () {
             }
 
             switch (dataType) {
-
+                case "BOOL":
+                    break;
                 case "FLOAT":
                     val = {explicitDouble: parseFloat(val)};
                     break;


### PR DESCRIPTION
Boolean values from checkboxes are converted to string. I don't know, if that works with the CCU, but Homegear does not accept that. Nice project by the way ;-).

Cheers,
Sathya
